### PR TITLE
Removes shell out to mysql client

### DIFF
--- a/lib/sequel_rake_tasks.rb
+++ b/lib/sequel_rake_tasks.rb
@@ -9,42 +9,33 @@ module Sequel
   class RakeTasks < ::Rake::TaskLib
     include ::Rake::DSL if defined?(::Rake::DSL)
 
-    attr_reader :connection,
-      :connection_config,
-      :migrator_klass,
-      :migrations_dir,
-      :migrations_opts,
-      :schema_file,
-      :seed_file,
-      :structure_file
-
     def initialize(options)
-      @connection        = options[:connection]
-      @connection_config = options[:connection_config]
-      @migrator_klass    = options[:migrator]
-      @migrations_dir    = options[:migrations_dir]
-      @migrations_opts   = options[:migrations_opts]
-      @schema_file       = options[:schema_file]
-      @seed_file         = options[:seed_file]
-      @structure_file    = options[:structure_file]
+      @options = options
       define_tasks
     end
 
+    private
+
     def db_commands
-      @db_commands ||= MysqlDbCommands.new(connection_config)
+      assert_option(:connection_config) do |connection_config|
+        MysqlDbCommands.new(connection_config)
+      end
     end
 
-    def migrator
-      @migrator ||= begin
-        args = [connection, migrations_dir]
-        args << migrations_opts if migrations_opts
-        migrator_klass.new(*args)
+    def assert_option(option, &block)
+      if value = get_option(option)
+        yield value
+      else
+        raise "`#{option}` option not defined!"
       end
+    end
+
+    def get_option(option)
+      @options[option]
     end
 
     def define_tasks
       namespace :db do
-
         desc 'Setup the database.'
         task :setup => [:create, :migrate]
 
@@ -52,7 +43,7 @@ module Sequel
         task :reset => [:drop, :setup]
 
         desc 'Create the database.'
-        task :create do |t, args|
+        task :create do
           db_commands.create_database
         end
 
@@ -61,67 +52,96 @@ module Sequel
           db_commands.drop_database
         end
 
-        desc 'Load the seeds'
+        desc 'Load the seeds.'
         task :seed do
-          load(seed_file)
+          assert_option(:seed_file) do |seed_file|
+            load(seed_file)
+          end
         end
 
         desc 'Migrate the database.'
         task :migrate do
-          migrator.run
-          Rake::Task['db:schema:dump'].invoke
+          assert_option(:migrator) do |migrator_klass|
+            assert_option(:migrations_dir) do |migrations_dir|
+              db_commands.migrate(migrator_klass, migrations_dir, get_option(:migrations_opts))
+              Rake::Task['db:schema:dump'].invoke if get_option(:schema_file)
+            end
+          end
         end
 
         namespace :schema do
-
           desc 'Dump the current database schema as a migration.'
           task :dump do
-            connection.extension :schema_dumper
-            text = connection.dump_schema_migration(same_db: false)
-            text = text.gsub(/ +$/, '') # remove trailing whitespace
-            File.open(schema_file, 'w') { |f| f.write(text) }
+            assert_option(:schema_file) do |schema_file|
+              db_commands.dump_schema(schema_file)
+            end
           end
 
           desc 'Loads the schema_file into the current environment\'s database'
           task :load do
-            eval(File.read schema_file).apply(connection, :up)
+            assert_option(:schema_file) do |schema_file|
+              db_commands.load_schema(schema_file)
+            end
           end
         end
 
         namespace :structure do
-
           desc 'Load the database structure file'
           task :load do
-            raise '`structure_file` option not defined!' unless structure_file
-            db_commands.load_sql_file(structure_file)
+            assert_option(:structure_file) do |structure_file|
+              db_commands.load_sql_file(structure_file)
+            end
           end
-
         end
-
       end
     end
-
   end
 
   class MysqlDbCommands
-
     def initialize(connection_config)
       @connection_config = connection_config
     end
 
     def drop_database
-      execute("DROP DATABASE IF EXISTS `#{database_name}`")
+      with_master_connection do |connection|
+        connection.execute("DROP DATABASE IF EXISTS `#{database_name}`")
+      end
     end
 
     def create_database
-      execute("CREATE DATABASE IF NOT EXISTS `#{database_name}` DEFAULT CHARACTER SET #{charset} DEFAULT COLLATE #{collation}")
+      with_master_connection do |connection|
+        connection.execute("CREATE DATABASE IF NOT EXISTS `#{database_name}` DEFAULT CHARACTER SET #{charset} DEFAULT COLLATE #{collation}")
+      end
     end
 
     def load_sql_file(filename)
-      commands = base_commands
-      commands << '--execute' << %{SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1}
-      commands << '--database' << database_name
-      system(*commands)
+      with_database_connection do |connection|
+        connection.execute("SET FOREIGN_KEY_CHECKS = 0; SOURCE #{filename}; SET FOREIGN_KEY_CHECKS = 1")
+      end
+    end
+
+    def load_schema(schema_file)
+      with_database_connection do |connection|
+        eval(File.read schema_file).apply(connection, :up)
+      end
+    end
+
+    def dump_schema(schema_file)
+      with_database_connection do |connection|
+        connection.extension :schema_dumper
+        text = connection.dump_schema_migration(same_db: false)
+        text = text.gsub(/ +$/, '') # remove trailing whitespace
+        File.open(schema_file, 'w') { |f| f.write(text) }
+      end
+    end
+
+    def migrate(migrator_klass, migrations_dir, migrations_opts)
+      with_database_connection do |connection|
+        args = [connection, migrations_dir]
+        args << migrations_opts if migrations_opts
+        migrator = migrator_klass.new(*args)
+        migrator.run
+      end
     end
 
     private
@@ -136,21 +156,6 @@ module Sequel
       connection_config[:username]
     end
 
-    def password
-      connection_config[:password]
-    end
-
-    def host
-    end
-
-    def host
-      connection_config[:host]
-    end
-
-    def port
-      connection_config[:port]
-    end
-
     def charset
       connection_config[:charset] || 'utf8'
     end
@@ -159,23 +164,21 @@ module Sequel
       connection_config[:collation] || 'utf8_unicode_ci'
     end
 
-    def execute(statement)
-      commands = base_commands
-      commands << '-e' << statement
-      system(*commands)
+    def with_database_connection(&block)
+      with_connection(connection_config, &block)
     end
 
-    def base_commands
-      commands = %w(mysql)
-      commands << "--user=#{Shellwords.escape(username)}" unless blank?(username)
-      commands << "--password=#{Shellwords.escape(password)}" unless blank?(password)
-      commands << "--host=#{host}" unless blank?(host)
-      commands
+    def with_master_connection(&block)
+      with_connection(connection_config.reject { |key, value| key.to_s == "database" }, &block)
     end
 
-    def blank?(str)
-      str.nil? || str.strip == ""
+    def with_connection(config, &block)
+      connection = Sequel.connect(config)
+      begin
+        yield connection
+      ensure
+        connection.disconnect
+      end
     end
-
   end
 end


### PR DESCRIPTION
Uses the Sequel client to connect to the master database and create
databases instead of shelling out to the mysql client.